### PR TITLE
Added support for AutoMapper v11

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           dotnet-version: |
             2.1.x
+            3.1.x
             5.0.x
       - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -33,6 +33,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            2.1.x
+            5.0.x
       - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            2.1.x
+            5.0.x
       - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           dotnet-version: |
             2.1.x
+            3.1.x
             5.0.x
       - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2

--- a/AutoFixture.Community.AutoMapper.sln
+++ b/AutoFixture.Community.AutoMapper.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutoFixture.Community.AutoM
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{1F01EA94-AA4F-4D1E-B9E7-47D0061430AC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoFixture.Community.AutoMapper10.Tests", "tests\AutoFixture.Community.AutoMapper10.Tests\AutoFixture.Community.AutoMapper10.Tests.csproj", "{6A817919-5378-4CE3-B237-4989D5BD72C9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,10 @@ Global
 		{3C33293F-F6C1-4794-B13E-C991A46B3D9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3C33293F-F6C1-4794-B13E-C991A46B3D9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3C33293F-F6C1-4794-B13E-C991A46B3D9E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A817919-5378-4CE3-B237-4989D5BD72C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A817919-5378-4CE3-B237-4989D5BD72C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A817919-5378-4CE3-B237-4989D5BD72C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A817919-5378-4CE3-B237-4989D5BD72C9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -58,6 +64,7 @@ Global
 		{821E5F93-5AC8-4B72-B218-06031E5324BC} = {1F01EA94-AA4F-4D1E-B9E7-47D0061430AC}
 		{8AF7A561-C7A4-4871-84AE-C41F86ABA0A8} = {1F01EA94-AA4F-4D1E-B9E7-47D0061430AC}
 		{3C33293F-F6C1-4794-B13E-C991A46B3D9E} = {1F01EA94-AA4F-4D1E-B9E7-47D0061430AC}
+		{6A817919-5378-4CE3-B237-4989D5BD72C9} = {1F01EA94-AA4F-4D1E-B9E7-47D0061430AC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F55E1A48-F5F2-401F-9BEF-F15527CE66DD}

--- a/Common.Tests.props
+++ b/Common.Tests.props
@@ -16,12 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0" Condition="$(TargetFramework.StartsWith('net4'))">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0" Condition="$(TargetFramework.StartsWith('net5.'))">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Common.props
+++ b/Common.props
@@ -7,7 +7,7 @@
     <Description>A library that integrates AutoFixture with AutoMapper.</Description>
     <PackageTags>AutoFixture;AutoMapper;Unit Testing;Tests</PackageTags>
     <PackageProjectUrl>https://github.com/aivascu/AutoFixture.Community.AutoMapper</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/aivascu/AutoFixture.Community.AutoMapper</RepositoryUrl>
+    <RepositoryUrl>https://github.com/aivascu/AutoFixture.Community.AutoMapper.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
 
     <PackageIcon>icon.png</PackageIcon>
@@ -18,6 +18,9 @@
 
     <!-- Embed source files that are not tracked by the source control manager in the PDB -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- Set the CheckEolTargetFramework property to false to fix the NETSDK1138 warning -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -28,7 +28,7 @@ partial class Build : NukeBuild
     readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
 
     [GitRepository] readonly GitRepository GitRepository;
-    [GitVersion(Framework = "netcoreapp3.0")] readonly GitVersion GitVersion;
+    [GitVersion] readonly GitVersion GitVersion;
 
     [Parameter] readonly bool Deterministic;
 
@@ -95,7 +95,7 @@ partial class Build : NukeBuild
                 .SetNoBuild(FinishedTargets.Contains(Compile))
                 .ResetVerbosity()
                 .SetResultsDirectory(TestResultsDirectory)
-                .SetLogger("trx")
+                .SetLoggers("trx")
                 .SetUseSourceLink(IsServerBuild)
                 .SetProcessArgumentConfigurator(a => a
                     .Add("/p:CheckEolTargetFramework=false")

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.2.1" />
-    <PackageDownload Include="coveralls.net" Version="[1.0.0]" />
-    <PackageDownload Include="coverlet.console" Version="[1.7.2]" />
-    <PackageDownload Include="GitVersion.Tool" Version="[5.1.1]" />
-    <PackageDownload Include="JetBrains.ReSharper.CommandLineTools" Version="[2020.1.3]" />
-    <PackageDownload Include="ReportGenerator" Version="[4.8.11]" />
+    <PackageReference Include="Nuke.Common" Version="5.3.0" />
+    <PackageDownload Include="coveralls.net" Version="[3.0.0]" />
+    <PackageDownload Include="coverlet.console" Version="[3.1.0]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[5.8.1]" />
+    <PackageDownload Include="JetBrains.ReSharper.CommandLineTools" Version="[2021.3.2]" />
+    <PackageDownload Include="ReportGenerator" Version="[5.0.2]" />
     <PackageDownload Include="xunit.runner.console" Version="[2.4.1]" />
   </ItemGroup>
 

--- a/src/AutoFixture.Community.AutoMapper/AutoFixture.Community.AutoMapper.csproj
+++ b/src/AutoFixture.Community.AutoMapper/AutoFixture.Community.AutoMapper.csproj
@@ -2,12 +2,20 @@
   <Import Project="../../Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.5.0" />
-    <PackageReference Include="AutoMapper" Version="8.0.0" />
+    <PackageReference Include="AutoMapper" Version="11.0.0" Condition="'$(TargetFramework)'=='netstandard2.1'" />
+  </ItemGroup>
+
+  <ItemGroup  Condition="'$(TargetFramework)'=='net461' OR '$(TargetFramework)'=='netstandard2.0' ">
+    <PackageReference Include="AutoMapper" Version="[8.0.0,11.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
+    <PackageReference Include="AutoMapper" Version="11.0.0"  />
   </ItemGroup>
 
 </Project>

--- a/src/AutoFixture.Community.AutoMapper/AutoMapperCustomization.cs
+++ b/src/AutoFixture.Community.AutoMapper/AutoMapperCustomization.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using AutoFixture.Kernel;
 using AutoMapper;
+
+#if !(NETSTANDARD2_1_OR_GREATER)
 using AutoMapper.Configuration;
+#endif
 
 namespace AutoFixture.Community.AutoMapper
 {

--- a/tests/AutoFixture.Community.AutoMapper.Tests/AutoFixture.Community.AutoMapper.Tests.csproj
+++ b/tests/AutoFixture.Community.AutoMapper.Tests/AutoFixture.Community.AutoMapper.Tests.csproj
@@ -2,11 +2,11 @@
   <Import Project="..\..\Common.Tests.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.0.0" />
+    <PackageReference Include="AutoMapper" Version="11.0.0" />
 
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />

--- a/tests/AutoFixture.Community.AutoMapper10.Tests/AutoFixture.Community.AutoMapper10.Tests.csproj
+++ b/tests/AutoFixture.Community.AutoMapper10.Tests/AutoFixture.Community.AutoMapper10.Tests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\Common.Tests.props" />
-  
+
   <PropertyGroup>
     <TargetFrameworks>net462;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="8.0.0" />
+    <PackageReference Include="AutoMapper" Version="10.0.0" />
 
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />

--- a/tests/AutoFixture.Community.AutoMapper9.Tests/AutoFixture.Community.AutoMapper9.Tests.csproj
+++ b/tests/AutoFixture.Community.AutoMapper9.Tests/AutoFixture.Community.AutoMapper9.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\Common.Tests.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,8 +23,15 @@
     <Compile Remove="..\AutoFixture.Community.AutoMapper.Tests\obj\**" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\AutoFixture.Community.AutoMapper\AutoFixture.Community.AutoMapper.csproj" />
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'" >
+    <ProjectReference Include="..\..\src\AutoFixture.Community.AutoMapper\AutoFixture.Community.AutoMapper.csproj">
+      <SetTargetFramework>TargetFramework=netstandard2.0</SetTargetFramework>
+    </ProjectReference>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='net462'" >
+    <ProjectReference Include="..\..\src\AutoFixture.Community.AutoMapper\AutoFixture.Community.AutoMapper.csproj">
+      <SetTargetFramework>TargetFramework=net461</SetTargetFramework>
+    </ProjectReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds support for AutoMapper v11

### Description
- Adds the .NET Standard 2.1 target framework to the library.
- Adds the AutoMapper v11 tests project
- Updates CI script to run the test on solution rather than individual projects

### Closed issues
<!-- List of issues it closes e.g. fixes #123 -->

### Checklist

- [x] Linked the issue(s) the PR closes
- [x] Implemented automated tests and checked coverage
- [x] Provided inline documentation comments for new public API
- [x] Ran the full solution build and validation locally
